### PR TITLE
fix: force tree-sitter version across optional peer dependency

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,7 @@
 
 ## Developer Workflows
 - **Install dependencies:**
-  - Use `npm install --legacy-peer-deps` (required for Tree-sitter peer deps)
+  - All tree-sitter grammar libraries need an override entry in package.json to align with the direct tree-sitter library version
 - **Build:**
   - `npm run build` (TypeScript → JavaScript)
   - `npm run clean` (remove build artifacts)
@@ -48,7 +48,7 @@
   - Import `URLDetector` and `LanguageManager` from the package for custom workflows.
 
 ## Project-Specific Notes
-- **Peer Dependency Issues:** Always use `--legacy-peer-deps` with npm install.  Only allow upgrades of tree-sitter package if it includes prebuilts and you have verified compatibility.  Currently 0.22.4 is the latest release that includes prebuilts, 0.25.0 does not include prebuilts and will not work.
+- **Dependency Issues:** Only allow upgrades of tree-sitter package if it includes prebuilts and you have verified compatibility.  Currently 0.22.4 is the latest release that includes prebuilts, 0.25.0 does not include prebuilts and will not work.
 - **Documentation Sync:** Update both CLI code and README when adding options; tests will fail if out of sync.
 
 ---

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - run: npm ci --legacy-peer-deps
+    - run: npm ci
     - run: npm run build
     - run: npm run test:coverage
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
-      - run: npm ci --legacy-peer-deps
+      - run: npm ci
       - run: npm run build
       - run: npm test
       - run: npm run pkg:all

--- a/README.md
+++ b/README.md
@@ -337,15 +337,13 @@ tests/
 
 ### Local Development Setup
 
-When cloning this project for local development, you'll need to use the `--legacy-peer-deps` flag due to complex peer dependencies across Tree-sitter packages:
-
 ```bash
 # Clone the repository
 git clone https://github.com/morgan-stanley/url-detector.git
 cd url-detector
 
-# Install dependencies with legacy peer deps support
-npm install --legacy-peer-deps
+# Install dependencies
+npm install
 ```
 
 ### Building

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "minimatch": "^10.0.3",
         "p-limit": "^3.1.0",
         "tree-sitter": "^0.22.4",
-        "tree-sitter-bash": "0.21.0",
-        "tree-sitter-c": "0.21.4",
+        "tree-sitter-bash": "^0.21.0",
+        "tree-sitter-c": "^0.21.4",
         "tree-sitter-c-sharp": "^0.23.1",
         "tree-sitter-cpp": "^0.23.4",
         "tree-sitter-css": "^0.23.2",
@@ -5125,6 +5125,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -78,5 +78,67 @@
     "rimraf": "^6.0.1",
     "ts-jest": "^29.3.4",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "@tree-sitter-grammars/tree-sitter-kotlin": {
+      "tree-sitter": "0.22.4"
+    },
+    "@tree-sitter-grammars/tree-sitter-toml": {
+      "tree-sitter": "0.22.4"
+    },
+    "@tree-sitter-grammars/tree-sitter-xml": {
+      "tree-sitter": "0.22.4"
+    },
+    "@tree-sitter-grammars/tree-sitter-yaml": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-bash": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-c": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-c-sharp": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-cpp": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-css": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-go": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-html": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-java": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-javascript": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-json": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-php": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-python": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-ruby": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-scala": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-swift": {
+      "tree-sitter": "0.22.4"
+    },
+    "tree-sitter-typescript": {
+      "tree-sitter": "0.22.4"
+    }
   }
 }


### PR DESCRIPTION
Eliminates need for --legacy-peer-deps.  Overrides broad range of fixed peer dependency on single version that is known to work.