### PR TITLE
Tighten glob-pattern sanitization to keep scan patterns within the target directory

### DIFF
--- a/src/pathSanitizer.ts
+++ b/src/pathSanitizer.ts
@@ -13,27 +13,63 @@
  */
 
 /**
- * Sanitizes glob patterns to prevent path traversal attacks
+ * Decodes percent-encoded dot sequences (including doubly-encoded forms
+ * such as `%252e`) to a fixed point, so traversal removal below sees the
+ * same characters whether a pattern arrived literal or encoded.
+ */
+function decodeEncodedDots(pattern: string): string {
+    let result = pattern;
+    let previous: string;
+    do {
+        previous = result;
+        result = result.replace(/%2e/gi, '.').replace(/%252e/gi, '%2e');
+    } while (result !== previous);
+    return result;
+}
+
+/**
+ * Sanitizes glob patterns to keep them scoped to the intended scan root.
+ *
+ * Decodes percent-encoded traversal sequences, removes relative `../`
+ * segments, and strips leading glob-negation (`!`), drive-letter
+ * (`C:`), and absolute-path (`/`) prefixes so a sanitized pattern always
+ * resolves to a relative path regardless of the caller's `cwd`. Every step
+ * is re-applied in a fixed-point loop so that removing one prefix or
+ * sequence can't uncover another one underneath it.
+ *
  * @param pattern - The glob pattern to sanitize
  * @returns Sanitized glob pattern
  */
 export function sanitizeGlobPattern(pattern: string): string {
-    return (
-        pattern
-            // Normalize path separators to forward slashes
-            .replace(/\\/g, '/')
-            // Remove dangerous traversal sequences
-            .replace(/\.\.\/+/g, '')
-            .replace(/\/\.\.$/g, '')
-            .replace(/^\.\.$/g, '')
-            .replace(/^\.\.\/+/g, '')
-            // Remove null bytes and other control characters
-            // eslint-disable-next-line no-control-regex
-            .replace(/[\x00-\x1f\x7f]/g, '')
-            // Remove URL encoding attempts for path traversal
-            .replace(/%2e%2e/gi, '')
-            .replace(/%252e%252e/gi, '')
-    );
+    let result = pattern
+        // Normalize path separators to forward slashes
+        .replace(/\\/g, '/')
+        // Remove null bytes and other control characters
+        // eslint-disable-next-line no-control-regex
+        .replace(/[\x00-\x1f\x7f]/g, '');
+
+    let previous: string;
+    do {
+        previous = result;
+
+        // Decode URL-encoded traversal attempts before stripping them.
+        result = decodeEncodedDots(result);
+
+        // Remove relative traversal segments: "../", a trailing "/..", or
+        // a bare "..", each only when properly bounded by a path
+        // separator (or the start/end of the pattern).
+        result = result.replace(/(^|\/)\.\.(\/|$)/g, '$1');
+
+        // Strip glob-negation, drive-letter, and absolute-path prefixes so
+        // the pattern can't escape the scan root regardless of fast-glob's
+        // cwd.
+        result = result
+            .replace(/^!+/, '')
+            .replace(/^[A-Za-z]:\/?/, '')
+            .replace(/^\/+/, '');
+    } while (result !== previous);
+
+    return result;
 }
 
 /**

--- a/src/pathSanitizer.ts
+++ b/src/pathSanitizer.ts
@@ -57,8 +57,13 @@ export function sanitizeGlobPattern(pattern: string): string {
 
         // Remove relative traversal segments: "../", a trailing "/..", or
         // a bare "..", each only when properly bounded by a path
-        // separator (or the start/end of the pattern).
-        result = result.replace(/(^|\/)\.\.(\/|$)/g, '$1');
+        // separator (or the start/end of the pattern). A trailing "/.."
+        // (preceded by a separator, with nothing after it) is dropped
+        // entirely rather than leaving the separator behind - there's no
+        // following segment left to join it to.
+        result = result.replace(/(^|\/)\.\.(\/|$)/g, (_match, before: string, after: string) =>
+            before === '/' && after === '' ? '' : before,
+        );
 
         // Strip glob-negation, drive-letter, and absolute-path prefixes so
         // the pattern can't escape the scan root regardless of fast-glob's

--- a/tests/pathSanitizer.test.ts
+++ b/tests/pathSanitizer.test.ts
@@ -73,6 +73,16 @@ describe('Path Sanitizer', () => {
             expect(sanitizeGlobPattern('C:../etc/passwd')).toBe('etc/passwd');
         });
 
+        it('should drop a trailing "/.." entirely rather than leaving a trailing separator', () => {
+            // A trailing separator changes what the pattern matches under fast-glob's
+            // onlyFiles: true (see urlDetector.ts), so "src/.." must fully collapse to
+            // "src", not "src/".
+            expect(sanitizeGlobPattern('src/..')).toBe('src');
+            expect(sanitizeGlobPattern('foo/bar/..')).toBe('foo/bar');
+            expect(sanitizeGlobPattern('a/../..')).toBe('a');
+            expect(sanitizeGlobPattern('src\\..')).toBe('src');
+        });
+
         it('should preserve safe glob patterns', () => {
             expect(sanitizeGlobPattern('**/*.js')).toBe('**/*.js');
             expect(sanitizeGlobPattern('src/**/*.{ts,js}')).toBe('src/**/*.{ts,js}');

--- a/tests/pathSanitizer.test.ts
+++ b/tests/pathSanitizer.test.ts
@@ -41,9 +41,36 @@ describe('Path Sanitizer', () => {
         });
 
         it('should remove URL-encoded path traversal attempts', () => {
-            expect(sanitizeGlobPattern('%2e%2e/etc/*')).toBe('/etc/*');
-            expect(sanitizeGlobPattern('%252e%252e/config/*')).toBe('/config/*');
-            expect(sanitizeGlobPattern('src/%2E%2E/secret')).toBe('src//secret');
+            expect(sanitizeGlobPattern('%2e%2e/etc/*')).toBe('etc/*');
+            expect(sanitizeGlobPattern('%252e%252e/config/*')).toBe('config/*');
+            expect(sanitizeGlobPattern('src/%2E%2E/secret')).toBe('src/secret');
+        });
+
+        it('should decode doubly-encoded traversal sequences to the same result as single-encoded ones', () => {
+            expect(sanitizeGlobPattern('%2e%2e/%2e%2e/etc/shadow')).toBe('etc/shadow');
+            expect(sanitizeGlobPattern('%252e%252e/%252e%252e/etc/shadow')).toBe('etc/shadow');
+        });
+
+        it('should reject absolute paths', () => {
+            expect(sanitizeGlobPattern('/etc/passwd')).toBe('etc/passwd');
+            expect(sanitizeGlobPattern('//etc/passwd')).toBe('etc/passwd');
+        });
+
+        it('should reject Windows drive-letter prefixes', () => {
+            expect(sanitizeGlobPattern('C:/Windows/System32/*')).toBe('Windows/System32/*');
+            expect(sanitizeGlobPattern('c:\\Windows\\System32\\*')).toBe('Windows/System32/*');
+            expect(sanitizeGlobPattern('D:secret/*')).toBe('secret/*');
+        });
+
+        it('should reject leading glob-negation prefixes', () => {
+            expect(sanitizeGlobPattern('!secret/**')).toBe('secret/**');
+            expect(sanitizeGlobPattern('!!secret/**')).toBe('secret/**');
+        });
+
+        it('should reject combined absolute/negation/traversal/encoding prefixes', () => {
+            expect(sanitizeGlobPattern('!/../../etc/passwd')).toBe('etc/passwd');
+            expect(sanitizeGlobPattern('!C:/../Windows/*')).toBe('Windows/*');
+            expect(sanitizeGlobPattern('C:../etc/passwd')).toBe('etc/passwd');
         });
 
         it('should preserve safe glob patterns', () => {
@@ -110,9 +137,26 @@ describe('Path Sanitizer', () => {
             const pattern = 'safe/path\x00../../../etc/passwd';
             const sanitized = sanitizeGlobPattern(pattern);
 
-            expect(sanitized).toBe('safe/pathetc/passwd');
             expect(sanitized).not.toContain('\x00');
-            expect(sanitized).not.toMatch(/\.\./);
+            // The null byte is stripped before segment boundaries are considered, so the
+            // first ".." fuses onto "path" as a literal (inert) segment name rather than
+            // a real traversal segment. The two properly-bounded segments after it are
+            // still removed, and no exploitable "../" remains.
+            expect(sanitized).toBe('safe/path../etc/passwd');
+            expect(sanitized).not.toMatch(/(^|\/)\.\.(\/|$)/);
+        });
+
+        it('should reject absolute, drive-letter, and negation prefixes even when combined with traversal', () => {
+            const maliciousPatterns = ['/etc/passwd', 'C:/Windows/System32/*', '!secret/**', '!/../../etc/passwd'];
+
+            const sanitized = sanitizeGlobPatterns(maliciousPatterns);
+
+            sanitized.forEach(pattern => {
+                expect(pattern).not.toMatch(/^\//);
+                expect(pattern).not.toMatch(/^[A-Za-z]:/);
+                expect(pattern).not.toMatch(/^!/);
+                expect(pattern).not.toMatch(/(^|\/)\.\.(\/|$)/);
+            });
         });
     });
 });


### PR DESCRIPTION
## Summary
- Decodes percent-encoded traversal sequences (including doubly-encoded forms) before stripping them, so encoded and literal `../` are treated the same
- Removes `../` segments to a fixed point instead of a single pass, so multi-segment traversal sequences are fully resolved
- Rejects leading absolute-path, Windows drive-letter, and glob-negation (`!`) prefixes, so a sanitized pattern always resolves relative to the intended scan root

## Test plan
- [x] `npm test` - full suite passes, including updated/new cases in `tests/pathSanitizer.test.ts` covering encoding, absolute paths, drive letters, negation, and combined cases
- [x] `npm run build` - clean compile