### PR TITLE
Improve CSV escaping and strip control characters from detected URLs for cleaner, portable output

### DIFF
--- a/src/outputFormatter.ts
+++ b/src/outputFormatter.ts
@@ -207,10 +207,30 @@ export class OutputFormatter {
         return Array.from(urls);
     }
 
-    private escapeCsv(value: string | number): string {
-        const strValue = typeof value === 'string' ? value : value.toString();
+    /**
+     * Prefixes a cell value with a single quote if it starts with a character that
+     * spreadsheet applications (Excel, LibreOffice, Google Sheets) interpret as the
+     * start of a formula. This keeps scanned filenames and URLs from being evaluated
+     * as formulas when the CSV output is opened in a spreadsheet.
+     */
+    private neutralizeFormula(value: string): string {
+        if (/^[=+\-@\t\r]/.test(value)) {
+            return `'${value}`;
+        }
 
-        if (strValue.includes(',') || strValue.includes('"') || strValue.includes('\n')) {
+        return value;
+    }
+
+    private escapeCsv(value: string | number): string {
+        const strValue = this.neutralizeFormula(typeof value === 'string' ? value : value.toString());
+
+        if (
+            strValue.includes(',') ||
+            strValue.includes('"') ||
+            strValue.includes('\n') ||
+            strValue.includes('\t') ||
+            strValue.includes('\r')
+        ) {
             return `"${strValue.replace(/"/g, '""')}"`;
         }
 

--- a/src/urlDetector.ts
+++ b/src/urlDetector.ts
@@ -111,7 +111,8 @@ export class URLDetector {
         this.logger = logger;
         this.parser = new Parser();
         this.languageManager = new LanguageManager(this.logger);
-        this.urlPattern = /(?:https?:\/\/|\/\/(?=[a-zA-Z0-9.-]+[a-zA-Z]))[^\s<>"'`${}]+/g;
+        // eslint-disable-next-line no-control-regex
+        this.urlPattern = /(?:https?:\/\/|\/\/(?=[a-zA-Z0-9.-]+[a-zA-Z]))[^\s<>"'`${}\x00-\x1f\x7f]+/g;
         this.commonSchemaPatterns = [
             /^\/\/W3C\/\/DTD/i,
             /^\/\/EN$/i,
@@ -413,7 +414,7 @@ export class URLDetector {
             const column = this.getColumnNumber(fullSourceCode, globalStart);
 
             const urlObj: URLMatch = {
-                url: match[0],
+                url: this.sanitizeUrlText(match[0]),
                 start: globalStart,
                 end: globalEnd,
                 line: line,
@@ -437,6 +438,17 @@ export class URLDetector {
         return this.commonSchemaPatterns.some(pattern => pattern.test(url));
     }
 
+    /**
+     * Strips ASCII control characters (including ESC and DEL) from an
+     * extracted URL. The urlPattern regex already excludes these from
+     * matching, so this is defense-in-depth against any control bytes
+     * that reach here through another path (e.g. a future regex change).
+     */
+    private sanitizeUrlText(url: string): string {
+        // eslint-disable-next-line no-control-regex
+        return url.replace(/[\x00-\x1f\x7f]/g, '');
+    }
+
     private fallbackDetection(sourceCode: string, filePath: string): URLMatch[] {
         const urls: URLMatch[] = [];
         const sourceLines = sourceCode.split('\n');
@@ -452,7 +464,7 @@ export class URLDetector {
             }
 
             const urlObj: URLMatch = {
-                url: match[0],
+                url: this.sanitizeUrlText(match[0]),
                 start: match.index,
                 end: match.index + match[0].length,
                 line: line,

--- a/tests/outputFormatter.test.ts
+++ b/tests/outputFormatter.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { OutputFormatter } from '../src/outputFormatter';
+import { FileResult } from '../src/urlDetector';
+import { Logger } from '../src/logger';
+
+function makeResult(file: string, url: string): FileResult {
+    return {
+        file,
+        urls: [{ url, start: 0, end: url.length, line: 1, column: 1, sourceType: 'string' }],
+    };
+}
+
+function captureLogger(): { logger: Logger; lines: string[] } {
+    const lines: string[] = [];
+    const logger: Logger = {
+        log: (message: string) => {
+            lines.push(message);
+        },
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+    };
+    return { logger, lines };
+}
+
+async function formatAsCsv(results: FileResult[]): Promise<string> {
+    const { logger, lines } = captureLogger();
+    const formatter = new OutputFormatter({ format: 'csv' }, logger);
+    await formatter.formatAndOutput(results);
+    return lines.join('\n');
+}
+
+describe('OutputFormatter CSV escaping', () => {
+    describe('formula neutralization', () => {
+        test.each([
+            ['=', '=cmd|calc'],
+            ['+', '+1+1'],
+            ['-', '-1+1'],
+            ['@', '@SUM(A1)'],
+        ])('prefixes a leading %s with a single quote', async (_label, value) => {
+            const csv = await formatAsCsv([makeResult(value, 'https://example.com')]);
+            const dataRow = csv.split('\n')[1];
+
+            expect(dataRow.startsWith(`'${value}`)).toBe(true);
+        });
+
+        test('prefixes a formula trigger appearing in a URL column', async () => {
+            const csv = await formatAsCsv([makeResult('safe.js', '=HYPERLINK("https://evil.example")')]);
+            const dataRow = csv.split('\n')[1];
+
+            expect(dataRow).toContain(`'=HYPERLINK`);
+        });
+
+        test('leaves ordinary values untouched', async () => {
+            const csv = await formatAsCsv([makeResult('src/app.ts', 'https://example.com/api')]);
+            const dataRow = csv.split('\n')[1];
+
+            expect(dataRow).not.toContain("'");
+        });
+    });
+
+    describe('quoting', () => {
+        test('quotes values containing a tab or carriage return', async () => {
+            const csvTab = await formatAsCsv([makeResult('name\twith-tab.js', 'https://example.com')]);
+            const csvCr = await formatAsCsv([makeResult('name\rwith-cr.js', 'https://example.com')]);
+
+            expect(csvTab.split('\n')[1]).toContain('"name\twith-tab.js"');
+            expect(csvCr.split('\n')[1]).toContain('"name\rwith-cr.js"');
+        });
+
+        test('still quotes and escapes existing comma/quote/newline cases', async () => {
+            const csv = await formatAsCsv([makeResult('a,"b".js', 'https://example.com')]);
+            const dataRow = csv.split('\n')[1];
+
+            expect(dataRow).toContain('"a,""b"".js"');
+        });
+    });
+});

--- a/tests/urlDetector.test.ts
+++ b/tests/urlDetector.test.ts
@@ -460,4 +460,30 @@ const url2 = "https://example.com";`;
             expect(urls[0].end).not.toBe(urls[1].end);
         });
     });
+
+    describe('Control character stripping', () => {
+        test('should truncate a URL match at an ESC-sequence payload', async () => {
+            // eslint-disable-next-line no-control-regex
+            const code = `const url = "https://example.com/\x1b[31mfake\x1b[0m";`;
+            const urls = await detector.detectURLs(code, 'javascript');
+
+            expect(urls).toHaveLength(1);
+            // eslint-disable-next-line no-control-regex
+            expect(urls[0].url).not.toMatch(/[\x00-\x1f\x7f]/);
+            // The control byte ends the match entirely, so nothing after it (including
+            // the ESC sequence's payload) is ever captured as part of the URL.
+            expect(urls[0].url).toBe('https://example.com/');
+        });
+
+        test('should stop a fallback-regex match at a control byte', async () => {
+            // eslint-disable-next-line no-control-regex
+            const code = `# Perl comment: http://example.com/path\x00../../etc/passwd`;
+            const urls = await detector.detectURLs(code, 'perl');
+
+            expect(urls).toHaveLength(1);
+            // eslint-disable-next-line no-control-regex
+            expect(urls[0].url).not.toMatch(/[\x00-\x1f\x7f]/);
+            expect(urls[0].url).toBe('http://example.com/path');
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- CSV output now prefixes any cell whose value starts with a spreadsheet formula trigger (`=`, `+`, `-`, `@`, tab, CR) with a single quote, so scanned filenames and URLs open as text instead of being evaluated as formulas; quoting is also extended to cover embedded tabs and carriage returns
- The URL-extraction regex now excludes ASCII control bytes (including ESC and DEL) from the match body, and extracted URLs are stripped of any residual control bytes as defense in depth, keeping stdout/JSON/CSV output free of embedded escape sequences

## Test plan
- [x] `npm test` - full suite passes, including new `tests/outputFormatter.test.ts` and additional cases in `tests/urlDetector.test.ts`
- [x] `npm run build` - clean compile