### PR TITLE
Validate custom language-parser module names against an approved list before loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ const customLanguages: LanguageConfig[] = [
 const languageManager = new LanguageManager(undefined, customLanguages);
 ```
 
+`module` must be the package name of an installed Tree-sitter grammar, following the
+standard naming convention: an unscoped `tree-sitter-<name>` package, or a scoped
+`@<scope>/tree-sitter-<name>` package (e.g. `@tree-sitter-grammars/tree-sitter-toml`).
+`LanguageManager` validates `module` against this convention before loading it; any
+other value (a file path, a non-grammar package name, etc.) is skipped with a warning
+instead of being loaded.
+
 ## How It Works
 
 1. **Language Detection**: Automatically detects programming language from file extension or filename

--- a/src/languageManager.ts
+++ b/src/languageManager.ts
@@ -75,6 +75,15 @@ export class LanguageManager {
     /* eslint-enable prettier/prettier */
 
     /**
+     * A valid npm name segment (scope name or package name): starts and ends with
+     * an alphanumeric character, optionally with single `.`, `_`, or `-` separators
+     * between alphanumeric runs - matching npm's actual package-naming rules
+     * (which allow `.` and `_` outside the leading position), not just the hyphen-only
+     * convention most Tree-sitter grammar names happen to use.
+     */
+    private static readonly NPM_NAME_SEGMENT = '[a-z0-9]+(?:[._-][a-z0-9]+)*';
+
+    /**
      * Matches the naming convention used by installable Tree-sitter grammar
      * packages: an unscoped `tree-sitter-<name>` package, or a scoped
      * `@<scope>/tree-sitter-<name>` package (e.g. `@tree-sitter-grammars/tree-sitter-toml`).
@@ -82,8 +91,10 @@ export class LanguageManager {
      * `require()`, so a config can only load an installed grammar package -
      * never an arbitrary file, relative, or absolute path.
      */
-    private static readonly APPROVED_MODULE_PATTERN =
-        /^(?:tree-sitter-[a-z0-9]+(?:-[a-z0-9]+)*|@[a-z0-9]+(?:-[a-z0-9]+)*\/tree-sitter-[a-z0-9]+(?:-[a-z0-9]+)*)$/;
+    private static readonly APPROVED_MODULE_PATTERN = new RegExp(
+        `^(?:tree-sitter-${LanguageManager.NPM_NAME_SEGMENT}` +
+            `|@${LanguageManager.NPM_NAME_SEGMENT}/tree-sitter-${LanguageManager.NPM_NAME_SEGMENT})$`,
+    );
 
     private languages: Map<string, unknown>;
     private languageConfigs: LanguageConfig[];

--- a/src/languageManager.ts
+++ b/src/languageManager.ts
@@ -23,7 +23,12 @@ export interface LanguageConfig {
     name: string;
     /** Human-readable display name for documentation (e.g., 'JavaScript', 'TypeScript') */
     displayName?: string;
-    /** Name of the Tree-sitter module to import (e.g., 'tree-sitter-javascript') */
+    /**
+     * Name of the Tree-sitter module to import (e.g., 'tree-sitter-javascript').
+     * Must follow the standard grammar-package naming convention - an unscoped
+     * `tree-sitter-<name>` or a scoped `@<scope>/tree-sitter-<name>` package - since
+     * `LanguageManager` validates it against that convention before loading it.
+     */
     module: string;
     /** Array of file extensions associated with this language (e.g., ['.js', '.ts']) */
     extensions: string[];
@@ -69,9 +74,42 @@ export class LanguageManager {
     ];
     /* eslint-enable prettier/prettier */
 
+    /**
+     * Matches the naming convention used by installable Tree-sitter grammar
+     * packages: an unscoped `tree-sitter-<name>` package, or a scoped
+     * `@<scope>/tree-sitter-<name>` package (e.g. `@tree-sitter-grammars/tree-sitter-toml`).
+     * `module` is validated against this pattern before it's ever passed to
+     * `require()`, so a config can only load an installed grammar package -
+     * never an arbitrary file, relative, or absolute path.
+     */
+    private static readonly APPROVED_MODULE_PATTERN =
+        /^(?:tree-sitter-[a-z0-9]+(?:-[a-z0-9]+)*|@[a-z0-9]+(?:-[a-z0-9]+)*\/tree-sitter-[a-z0-9]+(?:-[a-z0-9]+)*)$/;
+
     private languages: Map<string, unknown>;
     private languageConfigs: LanguageConfig[];
     private logger: Logger;
+
+    /**
+     * Returns a deep-enough copy of a language config so that mutating the
+     * caller's original object after it's handed to the manager (e.g. via
+     * the constructor's `customLanguages` argument, or `addLanguage`/
+     * `updateLanguage`) can't change what gets validated and loaded here.
+     */
+    private static cloneLanguageConfig(config: LanguageConfig): LanguageConfig {
+        return {
+            ...config,
+            extensions: [...config.extensions],
+            filenames: config.filenames ? [...config.filenames] : undefined,
+        };
+    }
+
+    /**
+     * Checks whether a module specifier matches the approved Tree-sitter
+     * grammar package naming convention (see APPROVED_MODULE_PATTERN).
+     */
+    private isApprovedModule(moduleName: string): boolean {
+        return LanguageManager.APPROVED_MODULE_PATTERN.test(moduleName);
+    }
 
     /**
      * Creates a new LanguageManager instance with optional custom configuration.
@@ -98,7 +136,9 @@ export class LanguageManager {
     constructor(logger?: Logger, customLanguages?: LanguageConfig[]) {
         this.languages = new Map();
         this.logger = logger || NullLogger;
-        this.languageConfigs = customLanguages ? [...customLanguages] : [...LanguageManager.DEFAULT_LANGUAGES];
+        this.languageConfigs = customLanguages
+            ? customLanguages.map(config => LanguageManager.cloneLanguageConfig(config))
+            : LanguageManager.DEFAULT_LANGUAGES.map(config => LanguageManager.cloneLanguageConfig(config));
         this.loadLanguages();
     }
 
@@ -107,6 +147,14 @@ export class LanguageManager {
         this.languages.clear();
 
         for (const config of this.languageConfigs) {
+            if (!this.isApprovedModule(config.module)) {
+                this.logger.warn(
+                    `Refusing to load ${config.name} parser: module "${config.module}" is not an approved ` +
+                        `Tree-sitter grammar package name`,
+                );
+                continue;
+            }
+
             try {
                 // eslint-disable-next-line @typescript-eslint/no-require-imports
                 const languageModule = require(config.module);
@@ -160,11 +208,12 @@ export class LanguageManager {
      * ```
      */
     public addLanguage(config: LanguageConfig): void {
-        const existingIndex = this.languageConfigs.findIndex(c => c.name === config.name);
+        const clonedConfig = LanguageManager.cloneLanguageConfig(config);
+        const existingIndex = this.languageConfigs.findIndex(c => c.name === clonedConfig.name);
         if (existingIndex >= 0) {
-            this.languageConfigs[existingIndex] = config;
+            this.languageConfigs[existingIndex] = clonedConfig;
         } else {
-            this.languageConfigs.push(config);
+            this.languageConfigs.push(clonedConfig);
         }
         this.loadLanguages();
     }
@@ -220,7 +269,7 @@ export class LanguageManager {
     public updateLanguage(name: string, config: LanguageConfig): boolean {
         const index = this.languageConfigs.findIndex(c => c.name === name);
         if (index >= 0) {
-            this.languageConfigs[index] = { ...config, name };
+            this.languageConfigs[index] = { ...LanguageManager.cloneLanguageConfig(config), name };
             this.loadLanguages();
             return true;
         }

--- a/tests/languageManager.test.ts
+++ b/tests/languageManager.test.ts
@@ -94,6 +94,22 @@ describe('LanguageManager', () => {
             expect(warnings.some(w => w.includes('Failed to load'))).toBe(true);
         });
 
+        test('should allow scoped grammar packages using npm-valid dot or underscore in the scope name', () => {
+            const { logger, warnings } = captureWarnings();
+            const customLanguages: LanguageConfig[] = [
+                { name: 'foo', module: '@my.scope/tree-sitter-foo', extensions: ['.foo'] },
+                { name: 'bar', module: '@my_scope/tree-sitter-bar', extensions: ['.bar'] },
+            ];
+
+            new LanguageManager(logger, customLanguages);
+
+            // Neither package is installed, so loading fails - but at require(), not at the
+            // allowlist check. npm allows '.' and '_' in scope names outside the leading
+            // position, so these must not be rejected as "not an approved" module name.
+            expect(warnings.some(w => w.includes('not an approved'))).toBe(false);
+            expect(warnings.filter(w => w.includes('Failed to load'))).toHaveLength(2);
+        });
+
         test('addLanguage should skip a disallowed module and warn', () => {
             const { logger, warnings } = captureWarnings();
             const customManager = new LanguageManager(logger);

--- a/tests/languageManager.test.ts
+++ b/tests/languageManager.test.ts
@@ -12,7 +12,22 @@
  * and limitations under the License.
  */
 
-import { LanguageManager } from '../src/languageManager';
+import { LanguageManager, LanguageConfig } from '../src/languageManager';
+import { Logger } from '../src/logger';
+
+function captureWarnings(): { logger: Logger; warnings: string[] } {
+    const warnings: string[] = [];
+    const logger: Logger = {
+        log: () => {},
+        info: () => {},
+        warn: (message: string) => {
+            warnings.push(message);
+        },
+        error: () => {},
+        debug: () => {},
+    };
+    return { logger, warnings };
+}
 
 describe('LanguageManager', () => {
     let manager: LanguageManager;
@@ -42,5 +57,69 @@ describe('LanguageManager', () => {
         expect(manager.getLanguage('JAVASCRIPT')).toBeDefined();
         expect(manager.getLanguage('JavaScript')).toBeDefined();
         expect(manager.getLanguage('javascript')).toBeDefined();
+    });
+
+    describe('module allowlist', () => {
+        test('should skip a path-like custom module and warn instead of requiring it', () => {
+            const { logger, warnings } = captureWarnings();
+            const customLanguages: LanguageConfig[] = [{ name: 'evil', module: '../../etc/passwd', extensions: ['.evil'] }];
+
+            const customManager = new LanguageManager(logger, customLanguages);
+
+            expect(customManager.getLanguage('.evil')).toBeUndefined();
+            expect(warnings.some(w => w.includes('not an approved'))).toBe(true);
+        });
+
+        test('should skip an absolute-path custom module and warn instead of requiring it', () => {
+            const { logger, warnings } = captureWarnings();
+            const customLanguages: LanguageConfig[] = [{ name: 'evil', module: '/etc/passwd', extensions: ['.evil'] }];
+
+            const customManager = new LanguageManager(logger, customLanguages);
+
+            expect(customManager.getLanguage('.evil')).toBeUndefined();
+            expect(warnings.some(w => w.includes('not an approved'))).toBe(true);
+        });
+
+        test('should allow a properly-named grammar package through validation, even if not installed', () => {
+            const { logger, warnings } = captureWarnings();
+            const customLanguages: LanguageConfig[] = [
+                { name: 'rust', module: 'tree-sitter-rust', extensions: ['.rs'] },
+            ];
+
+            new LanguageManager(logger, customLanguages);
+
+            // "tree-sitter-rust" is not installed in this project, so loading fails - but it
+            // must fail at require() (module not found), never at the allowlist check itself.
+            expect(warnings.some(w => w.includes('not an approved'))).toBe(false);
+            expect(warnings.some(w => w.includes('Failed to load'))).toBe(true);
+        });
+
+        test('addLanguage should skip a disallowed module and warn', () => {
+            const { logger, warnings } = captureWarnings();
+            const customManager = new LanguageManager(logger);
+
+            customManager.addLanguage({ name: 'evil2', module: '../../etc/shadow', extensions: ['.evil2'] });
+
+            expect(customManager.getLanguage('.evil2')).toBeUndefined();
+            expect(warnings.some(w => w.includes('not an approved'))).toBe(true);
+        });
+    });
+
+    describe('customLanguages isolation', () => {
+        test('should not be affected by mutating the customLanguages array or its objects after construction', () => {
+            const customLanguages: LanguageConfig[] = [{ name: 'rust', module: 'tree-sitter-rust', extensions: ['.rs'] }];
+
+            const customManager = new LanguageManager(undefined, customLanguages);
+
+            // Mutate the caller's original config object and array after handing them to the manager.
+            customLanguages[0].module = '../../etc/passwd';
+            customLanguages[0].extensions.push('.hacked');
+            customLanguages.push({ name: 'sneaky', module: '../../etc/shadow', extensions: ['.sneaky'] });
+
+            const configs = customManager.getLanguageConfigs();
+            expect(configs).toHaveLength(1);
+            expect(configs[0].module).toBe('tree-sitter-rust');
+            expect(configs[0].extensions).toEqual(['.rs']);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- `LanguageManager.loadLanguages` now checks each config's module specifier against the standard Tree-sitter grammar package naming convention (`tree-sitter-<name>` or `@<scope>/tree-sitter-<name>`) before ever passing it to `require()`; anything else (a file path, an arbitrary package name) is skipped with a warning
- The check re-runs on every load, so it also covers configs added later via `addLanguage`/`updateLanguage`
- `customLanguages` configs are now deep-copied when stored, so mutating a caller's config object or array after construction can't change what the manager has already validated and loaded
- Documents the `module` contract for `customLanguages` in the README

## Test plan
- [x] `npm test` - full suite passes, including new cases in `tests/languageManager.test.ts`
- [x] `npm run build` - clean compile